### PR TITLE
Set request language to target language

### DIFF
--- a/lib/translate.js
+++ b/lib/translate.js
@@ -36,7 +36,7 @@ module.exports = function() {
   callback = _.isFunction(callback) ? callback : _.noop;
 
   const url = "https://translate.google.com/translate_a/single"
-    + "?client=at&dt=t&dt=ld&dt=qca&dt=rm&dt=bd&dj=1&hl=es-ES&ie=UTF-8"
+    + "?client=at&dt=t&dt=ld&dt=qca&dt=rm&dt=bd&dj=1&hl=" + targetLang + "&ie=UTF-8"
     + "&oe=UTF-8&inputm=2&otf=2&iid=1dd3b944-fa62-4b55-b330-74909a99969e";
 
   const data = {


### PR DESCRIPTION
Without this I was only getting results in the `hl` language rather than what I specified in `targetLang`.
